### PR TITLE
BugFix - Timestmaps with Null in ExitDateTuime were not correctly displayed in the UI and exported to csv.

### DIFF
--- a/Tutti/Applications/TouchUI/Tools/FileExport/Strategies/CSV/ExportCsvStrategy.cs
+++ b/Tutti/Applications/TouchUI/Tools/FileExport/Strategies/CSV/ExportCsvStrategy.cs
@@ -35,11 +35,17 @@ namespace TouchUI.Tools.FileExport.Strategies.CSV
             using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
             {
                 csv.Context.RegisterClassMap<TimeStampMap>();
+                //Initial information
                 csv.WriteField($"Includes all records within: {exportContent.ReportingDatesMinimum} - {exportContent.ReportingDatesMaximum}");
                 csv.NextRecord();
                 csv.WriteField($"Created on: {exportContent.CreationDate}");
                 csv.NextRecord();
                 csv.NextRecord();
+                //Header
+                csv.WriteField("Full Name");
+                csv.WriteHeader(typeof(TimeStamp));
+                csv.NextRecord();
+                //Records
                 foreach (var user in exportContent.Users)
                 {
                     foreach(var timestamp in user.TimeStamps)

--- a/Tutti/Applications/TouchUI/ViewModels/HomeViewModel.cs
+++ b/Tutti/Applications/TouchUI/ViewModels/HomeViewModel.cs
@@ -40,7 +40,6 @@ namespace TouchUI.ViewModels
             ILoginService loginService)
             : base(navigationService, loginService)
         {
-            _logger.Debug("Creating main view model.".Here());
             _dataService = dataService;
             _idDeviceService = idDeviceService;
             InitializeSubscribtions();

--- a/Tutti/Applications/TouchUI/ViewModels/NavigationViewModelBase.cs
+++ b/Tutti/Applications/TouchUI/ViewModels/NavigationViewModelBase.cs
@@ -1,8 +1,11 @@
 ﻿using DataService.Models;
+using Framework.ExtensionMethods;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using System.Windows.Threading;
 using TouchUI.Commands;
@@ -14,6 +17,7 @@ namespace TouchUI.ViewModels
 {
     public abstract class NavigationViewModelBase : ViewModelBase
     {
+        private readonly ILogger _logger = Log.Logger.ForContext<NavigationViewModelBase>();
         protected readonly INavigationService NavigationService;
         protected readonly ILoginService LoginService;
         private ICommand _navigationCommand;
@@ -30,6 +34,7 @@ namespace TouchUI.ViewModels
 
         public NavigationViewModelBase(INavigationService navigationService, ILoginService loginService)
         {
+            _logger.Debug($"Opening ViewModel of type {GetType()}.".Here());
             NavigationService = navigationService;
             LoginService = loginService;
             _navigationCommand = new NavigationCommand(NavigationService);

--- a/Tutti/Services/DataServiceSql/DataServiceSqlTimeStamps.cs
+++ b/Tutti/Services/DataServiceSql/DataServiceSqlTimeStamps.cs
@@ -50,7 +50,7 @@ namespace Services.DataServiceSql
                 timeStamps.AddRange(context.TimeStamps.Where(timeStamp =>
                                                             timeStamp.UserId == userId
                                                             && timeStamp.EntryDate >= minDateTime
-                                                            && timeStamp.ExitDate <= maxDateTime));
+                                                            && (timeStamp.ExitDate <= maxDateTime || timeStamp.ExitDate == null)));
             }
             return timeStamps;
         }


### PR DESCRIPTION
Corrected DB query for getting timestamps to include null values of ExitDateTime